### PR TITLE
[Feat] Home화면에 대한 멤버 관리를 위한 구조체 설계

### DIFF
--- a/WSShopping/Model/HomeContent.swift
+++ b/WSShopping/Model/HomeContent.swift
@@ -1,0 +1,42 @@
+//
+//  ResultContent.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 1/15/25.
+//
+
+import Foundation
+
+enum Contents {
+    case imageName
+    case labelText
+}
+
+struct HomeContent {
+    
+    static let title = "원선's 쇼핑치링치링"
+    static let placeholder = "브랜드, 상품, 프로필, 태그 등"
+    
+    var isValid: Bool
+  
+    func isValidCheck(content: Contents) -> String {
+        
+        switch content {
+        case .imageName:
+            if isValid {
+                return "shopping"
+            } else {
+                return "nono"
+            }
+        case .labelText:
+            if isValid {
+                return "이것도 사고 저것도 살래 :>"
+            } else {
+                return "2글자 이상으로 검색해주세요!"
+            }
+        }
+    }
+    
+}
+
+

--- a/WSShopping/ViewController/MainViewController.swift
+++ b/WSShopping/ViewController/MainViewController.swift
@@ -13,6 +13,8 @@ class MainViewController: UIViewController, UISearchBarDelegate {
     let searchbar = UISearchBar()
     let defaultImage = UIImageView()
     let defaultLabel = UILabel()
+    
+    let homecontent = HomeContent(isValid: true)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,22 +49,22 @@ extension MainViewController: ShoppingConfigure {
         
         defaultLabel.snp.makeConstraints {
             $0.centerX.equalTo(defaultImage)
-            $0.top.equalTo(defaultImage.snp.bottom).offset(-20)
+            $0.top.equalTo(defaultImage.snp.bottom).offset(homecontent.isValid ? -20 : -60)
             $0.width.equalTo(300)
         }
     }
     
     func configView() {
         view.backgroundColor = .systemBackground
-        navigationItem.title = "원선's 쇼핑치링치링"
+        navigationItem.title = HomeContent.title
         
         searchbar.searchBarStyle = .minimal
-        searchbar.placeholder = "브랜드, 상품, 프로필, 태그 등"
+        searchbar.placeholder = HomeContent.placeholder
         
-        defaultImage.image = UIImage(named: "shopping")
+        defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
         defaultImage.contentMode = .scaleAspectFit
         
-        defaultLabel.text = "이것도 사고 저것도 살래 :>"
+        defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
         defaultLabel.textColor = .label
         defaultLabel.font = .systemFont(ofSize: 15, weight: .semibold)
         defaultLabel.textAlignment = .center


### PR DESCRIPTION
## 한 일
1. 홈 화면에 대한 콘텐츠와 멤버 제어를 하드코딩이 아닌 모델을 설계해둔 후 사용해보고 싶었음
- 절대 변하지 않을 네비게이션 title과 서치바 placeholder는 static let으로 설계
- 콘텐츠 변화를 줄 Bool 타입의 변수 선언
- enum에 대한 변화를 구조체 내 인스턴스 메서드로 설정

(true, false 일 때 모습)

![image](https://github.com/user-attachments/assets/dbfc8783-5e29-46e0-b6bf-34ba6fceb9eb)

![image](https://github.com/user-attachments/assets/13565490-66bc-4835-a180-1ebff111a631)
