### PR TITLE
[Feat] #7 UISearchBar에 제약조건 걸기, 화면전환 연결

### DIFF
--- a/WSShopping/ViewController/MainViewController.swift
+++ b/WSShopping/ViewController/MainViewController.swift
@@ -18,6 +18,9 @@ class MainViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tap)
 
         configHierarchy()
         configLayout()
@@ -27,7 +30,12 @@ class MainViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         
-        searchbar.text = "" 
+        searchbar.text = ""
+    }
+    
+    @objc
+    func dismissKeyboard() {
+        view.endEditing(true)
     }
 
 }

--- a/WSShopping/ViewController/MainViewController.swift
+++ b/WSShopping/ViewController/MainViewController.swift
@@ -8,13 +8,13 @@
 import UIKit
 import SnapKit
 
-class MainViewController: UIViewController, UISearchBarDelegate {
+class MainViewController: UIViewController {
     
     let searchbar = UISearchBar()
     let defaultImage = UIImageView()
     let defaultLabel = UILabel()
     
-    let homecontent = HomeContent(isValid: true)
+    var homecontent = HomeContent(isValid: true)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,6 +26,29 @@ class MainViewController: UIViewController, UISearchBarDelegate {
 
 }
 
+// MARK: - 서치바 관련 액션
+extension MainViewController: UISearchBarDelegate {
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        
+        guard let keyword = searchBar.text else { return }
+        
+        switch keyword.count {
+        case 0..<2:
+            homecontent.isValid = false
+            defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
+            defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
+        case 2...:
+            // 화면 전환 시키기 & keyword 다음으로 전달
+            navigationController?.pushViewController(SearchResultViewController(), animated: true)
+        default:
+            break
+        }
+    }
+}
+
+
+// MARK: - 레이아웃 및 속성 설정
 extension MainViewController: ShoppingConfigure {
     func configHierarchy() {
         searchbar.delegate = self

--- a/WSShopping/ViewController/MainViewController.swift
+++ b/WSShopping/ViewController/MainViewController.swift
@@ -23,6 +23,12 @@ class MainViewController: UIViewController {
         configLayout()
         configView()
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        searchbar.text = "" 
+    }
 
 }
 
@@ -44,6 +50,8 @@ extension MainViewController: UISearchBarDelegate {
         default:
             break
         }
+        
+        view.endEditing(true)
     }
 }
 

--- a/WSShopping/ViewController/MainViewController.swift
+++ b/WSShopping/ViewController/MainViewController.swift
@@ -31,12 +31,17 @@ class MainViewController: UIViewController {
         super.viewDidDisappear(animated)
         
         searchbar.text = ""
+        
+        homecontent.isValid = true
+        defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
+        defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
     }
     
     @objc
     func dismissKeyboard() {
         view.endEditing(true)
     }
+    
 
 }
 

--- a/WSShopping/ViewController/SearchResultViewController.swift
+++ b/WSShopping/ViewController/SearchResultViewController.swift
@@ -1,0 +1,18 @@
+//
+//  SearchResultViewController.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 1/15/25.
+//
+
+import UIKit
+
+class SearchResultViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+    }
+
+}


### PR DESCRIPTION
## 한 일
1. 입력값이 0~2미만 / 2이상일 때에 따라 제약 조건 설정
- 2 이상이면 화면 전환, 미만이면 화면의 이미지 변경되도록 

2. tapGestureRecognizer를 통해 화면 터치 시 키보드 내려가도록 설정
3. 다음 화면 갔다가 돌아왔을 때 서치바의 텍스트 초기화 및 키보드 내리기 설정

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-15 at 18 33 55](https://github.com/user-attachments/assets/4e4c9748-6f34-4d37-9055-7075f42157ad)
