### PR TITLE
[Feat] 검색결과 keyword 데이터 전달 해 결과 화면에서 네비게이션 타이틀로 설정

### DIFF
--- a/WSShopping/ViewController/MainViewController.swift
+++ b/WSShopping/ViewController/MainViewController.swift
@@ -59,7 +59,9 @@ extension MainViewController: UISearchBarDelegate {
             defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
         case 2...:
             // 화면 전환 시키기 & keyword 다음으로 전달
-            navigationController?.pushViewController(SearchResultViewController(), animated: true)
+            let vc = SearchResultViewController()
+            navigationController?.pushViewController(vc, animated: true)
+            vc.nvtitle = keyword
         default:
             break
         }
@@ -100,6 +102,8 @@ extension MainViewController: ShoppingConfigure {
     
     func configView() {
         view.backgroundColor = .systemBackground
+        navigationItem.backButtonTitle = ""
+        navigationController?.navigationBar.tintColor = .label
         navigationItem.title = HomeContent.title
         
         searchbar.searchBarStyle = .minimal

--- a/WSShopping/ViewController/SearchResultViewController.swift
+++ b/WSShopping/ViewController/SearchResultViewController.swift
@@ -8,11 +8,15 @@
 import UIKit
 
 class SearchResultViewController: UIViewController {
+    
+    var nvtitle = ""
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = .white
+        navigationItem.title = nvtitle
     }
 
 }
+


### PR DESCRIPTION
## 한 일
1. 메인 화면에서 화면 전환 하는 부분에서 검색결과 화면에 있는 프로퍼티에 데이터 전달
- 타이틀 이름은 결과 화면에서 교체
- backbuttontitle과 색상 설정은 이전 화면에서 설정


![Simulator Screen Recording - iPhone 16 Pro - 2025-01-15 at 18 56 45](https://github.com/user-attachments/assets/fb324214-6dd8-456c-a2ba-36762020affd)
