### PR TITLE
[Feat] #13 네이버 쇼핑 API 호출해 데이터 적용하고 자잘한 사용성 개선하기

### DIFF
--- a/WSShopping/CustomView/StrokeButton.swift
+++ b/WSShopping/CustomView/StrokeButton.swift
@@ -34,8 +34,8 @@ class StrokeButton: BaseButton {
         configuration?.cornerStyle = .medium
         configuration?.title = title
         configuration?.attributedTitle = AttributedString(title, attributes: container)
-        configuration?.baseForegroundColor = isTapped ? .label : .systemBackground
-        configuration?.baseBackgroundColor = isTapped ? .systemBackground : .label
+        configuration?.baseForegroundColor = isTapped ? .systemBackground : .label
+        configuration?.baseBackgroundColor = isTapped ? .label : .systemBackground
         configuration?.background.strokeColor = .label
         configuration?.background.strokeWidth = 1
     }

--- a/WSShopping/Extension/String+Extension.swift
+++ b/WSShopping/Extension/String+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  String+Extension.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 1/16/25.
+//
+
+import Foundation
+
+extension String {
+    var escapingHTML: String {
+        let pattern = #"<b>|<\/b>"#
+        
+        return self.replacingOccurrences(of: pattern, with: "", options: .regularExpression, range: nil)
+    }
+}

--- a/WSShopping/Model/Shopping.swift
+++ b/WSShopping/Model/Shopping.swift
@@ -25,3 +25,5 @@ struct ShoppingDetail: Decodable {
         case mallName
     }
 }
+
+var list: [ShoppingDetail] = []

--- a/WSShopping/Model/Shopping.swift
+++ b/WSShopping/Model/Shopping.swift
@@ -26,4 +26,6 @@ struct ShoppingDetail: Decodable {
     }
 }
 
+
+// 질문: 빈 배열을 이렇게 전역변수로 달랑 두는게 괜찮은지 (내부에서 따로 또 생성해서 하고싶지 않아서 이렇게 했는데...)
 var list: [ShoppingDetail] = []

--- a/WSShopping/Model/Shopping.swift
+++ b/WSShopping/Model/Shopping.swift
@@ -1,0 +1,27 @@
+//
+//  Shopping.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 1/16/25.
+//
+
+import Foundation
+
+struct Shopping: Decodable {
+    let total: Int
+    let items: [ShoppingDetail]
+}
+
+struct ShoppingDetail: Decodable {
+    let title: String
+    let image: String
+    let price: String
+    let mallName: String
+    
+    enum CodingKeys: String, CodingKey {
+        case title
+        case image
+        case price = "lprice"
+        case mallName
+    }
+}

--- a/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
+++ b/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
@@ -13,13 +13,9 @@ class SearchResultCollectionViewCell: UICollectionViewCell {
     static let id = "SearchResultCollectionViewCell"
     
     let thumnailImageView = UIImageView()
-    lazy var mallNameLabel = ResultLabel(title: mallName, size: 11, weight: .light, color: .systemGray3)
-    lazy var titleLabel = ResultLabel(title: title, size: 12, weight: .regular, color: .label, line: 2)
-    lazy var priceLabel = ResultLabel(title: price, size: 15, weight: .semibold, color: .label)
-    
-    var mallName = "mallname"
-    var title = "title"
-    var price = "price"
+    lazy var mallNameLabel = ResultLabel(title: "", size: 11, weight: .light, color: .lightGray)
+    lazy var titleLabel = ResultLabel(title: "", size: 12, weight: .regular, color: .label, line: 2)
+    lazy var priceLabel = ResultLabel(title: "", size: 15, weight: .semibold, color: .label)
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
+++ b/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
@@ -59,7 +59,7 @@ extension SearchResultCollectionViewCell {
         contentView.addSubview(priceLabel)
         
         mallNameLabel.snp.makeConstraints {
-            $0.top.equalTo(thumnailImageView.snp.bottom).offset(2)
+            $0.top.equalTo(thumnailImageView.snp.bottom).offset(3)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(8)
         }
         

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -35,12 +35,16 @@ class SearchResultViewController: UIViewController {
         for index in 0...3 {
             filteringButtons.append(StrokeButton(title: title[index], isTapped: isTapped[index]))
         }
-        
-        print(filteringButtons.description)
 
         configHierarchy()
         configLayout()
         configView()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        callRequest()
     }
     
     func collectionViewLayout() -> UICollectionViewFlowLayout {
@@ -55,6 +59,24 @@ class SearchResultViewController: UIViewController {
         layout.sectionInset = UIEdgeInsets(top: 8, left: sectionInsect, bottom: 8, right: sectionInsect)
         
         return layout
+    }
+    
+    func callRequest() {
+        
+        let url = "https://openapi.naver.com/v1/search/shop.json?query=\(nvtitle)&display=100"
+        let headers = HTTPHeaders(["X-Naver-Client-Id": APIKey.clientID, "X-Naver-Client-Secret": APIKey.clientSecret])
+        
+        AF.request(url, method: .get, headers: headers).responseDecodable(of: Shopping.self) { response in
+            
+            print(response.response?.statusCode)
+            
+            switch response.result {
+            case .success(let value):
+                dump(value)
+            case .failure(let error):
+                print(error)
+        }
+        }
     }
 
 }

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -102,8 +102,11 @@ extension SearchResultViewController: UICollectionViewDelegate, UICollectionView
         
         let url = currentArray.image
         guard let intPrice = Int(currentArray.price)?.formatted() else { return UICollectionViewCell() }
-        
-        cell.thumnailImageView.kf.setImage(with: URL(string: url))
+        let processor = DownsamplingImageProcessor(size: CGSize(width: cell.thumnailImageView.frame.width, height: cell.thumnailImageView.frame.height))
+        cell.thumnailImageView.kf.setImage(with: URL(string: url),
+                                           options: [.processor(processor),
+                                                     .scaleFactor(UIScreen.main.scale),
+                                                     .cacheOriginalImage])
         cell.thumnailImageView.contentMode = .scaleAspectFill
         cell.mallNameLabel.text = currentArray.mallName
         cell.titleLabel.text = currentArray.title

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -89,15 +89,19 @@ class SearchResultViewController: UIViewController {
         case "정확도":
             callRequest(filter: "sim")
             reloadButtonColor(button: button)
+            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
         case "날짜순":
             callRequest(filter: "date")
             reloadButtonColor(button: button)
+            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
         case "가격높은순":
             callRequest(filter: "dsc")
             reloadButtonColor(button: button)
+            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
         case "가격낮은순":
             callRequest(filter: "asc")
             reloadButtonColor(button: button)
+            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
         default:
             print("title error")
             break

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -86,19 +86,19 @@ class SearchResultViewController: UIViewController {
         let title = button.titleLabel?.text
         
         switch title {
-        case "정확도":
+        case StrokeButton.titleList[0]:
             callRequest(filter: "sim")
             reloadButtonColor(button: button)
             collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
-        case "날짜순":
+        case StrokeButton.titleList[1]:
             callRequest(filter: "date")
             reloadButtonColor(button: button)
             collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
-        case "가격높은순":
+        case StrokeButton.titleList[2]:
             callRequest(filter: "dsc")
             reloadButtonColor(button: button)
             collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
-        case "가격낮은순":
+        case StrokeButton.titleList[3]:
             callRequest(filter: "asc")
             reloadButtonColor(button: button)
             collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -89,19 +89,19 @@ class SearchResultViewController: UIViewController {
         case StrokeButton.titleList[0]:
             callRequest(filter: "sim")
             reloadButtonColor(button: button)
-            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+            scrollToUp()
         case StrokeButton.titleList[1]:
             callRequest(filter: "date")
             reloadButtonColor(button: button)
-            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+            scrollToUp()
         case StrokeButton.titleList[2]:
             callRequest(filter: "dsc")
             reloadButtonColor(button: button)
-            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+            scrollToUp()
         case StrokeButton.titleList[3]:
             callRequest(filter: "asc")
             reloadButtonColor(button: button)
-            collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+            scrollToUp()
         default:
             print("title error")
             break
@@ -115,6 +115,10 @@ class SearchResultViewController: UIViewController {
         }
         button.configuration?.baseBackgroundColor = .label
         button.configuration?.baseForegroundColor = .systemBackground
+    }
+    
+    func scrollToUp() {
+        collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
     }
 
 }

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -137,8 +137,11 @@ extension SearchResultViewController: UICollectionViewDelegate, UICollectionView
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchResultCollectionViewCell.id, for: indexPath) as? SearchResultCollectionViewCell else { return UICollectionViewCell() }
         
         let url = currentArray.image
+        
         guard let intPrice = Int(currentArray.price)?.formatted() else { return UICollectionViewCell() }
+        
         let processor = DownsamplingImageProcessor(size: CGSize(width: cell.thumnailImageView.frame.width, height: cell.thumnailImageView.frame.height))
+        
         cell.thumnailImageView.kf.setImage(with: URL(string: url),
                                            options: [.processor(processor),
                                                      .scaleFactor(UIScreen.main.scale),

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Alamofire
+import Kingfisher
 import SnapKit
 
 class SearchResultViewController: UIViewController {
@@ -24,7 +25,7 @@ class SearchResultViewController: UIViewController {
     }()
     
     var nvtitle = ""
-    var resultCount = "222,222,222개의 검색결과"
+    var resultCount = ""
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,12 +40,14 @@ class SearchResultViewController: UIViewController {
         configHierarchy()
         configLayout()
         configView()
+        
+        callRequest()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        callRequest()
+//        callRequest()
     }
     
     func collectionViewLayout() -> UICollectionViewFlowLayout {
@@ -72,7 +75,10 @@ class SearchResultViewController: UIViewController {
             
             switch response.result {
             case .success(let value):
-                dump(value)
+                self.resultCountLabel.text = String(value.total.formatted()) + "개의 검색결과"
+                list = value.items
+                
+                self.collectionView.reloadData()
             case .failure(let error):
                 print(error)
         }
@@ -83,16 +89,25 @@ class SearchResultViewController: UIViewController {
 
 // MARK: - collectionView 설정
 extension SearchResultViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 100
+        return list.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
+        let currentArray = list[indexPath.row]
+        
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchResultCollectionViewCell.id, for: indexPath) as? SearchResultCollectionViewCell else { return UICollectionViewCell() }
         
-        cell.thumnailImageView.image = UIImage(named: "zzamong")
+        let url = currentArray.image
+        guard let intPrice = Int(currentArray.price)?.formatted() else { return UICollectionViewCell() }
+        
+        cell.thumnailImageView.kf.setImage(with: URL(string: url))
         cell.thumnailImageView.contentMode = .scaleAspectFill
+        cell.mallNameLabel.text = currentArray.mallName
+        cell.titleLabel.text = currentArray.title
+        cell.priceLabel.text = String(intPrice)
         
         return cell
     }


### PR DESCRIPTION
## 한 일
1. 네이버 API request, response 진행
- 인증키는 APIKey로 숨겨둠

2. 임의 데이터 대신 요청받은 데이터로 교체
- 임의 데이터도 요청받을 데이터로 고려해보기 (단순하게 해두니, 추후 배열로 해서 바꾸는게 약간 번거로웠음)

3. 다량의 네트워크 사진을 받으면 버퍼링이 생겨 다운샘플링 진행
- Kingfisher에서 제공하는 기능 사용

4. 필터링(정렬) 버튼 클릭 시 작동하도록 구현
- 만들어 두었던 StrokeButton의 열거형 사용해 switch문으로 교체
- url의 일부를 변수로 두어 parameter 받도록함
- 버튼의 색상도 교체

5. 정렬 바뀌었을 때 스크롤 상단으로 올라가도록 구현
- collectionView의 기능 중 scrollToItem 활용

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-16 at 09 11 18](https://github.com/user-attachments/assets/6cab0afb-eefa-44c7-a18f-2dda4ebad5fc)
