### PR TITLE
[Refactor] #17 메인화면 비즈니스 로직 분리

### DIFF
--- a/WSShopping.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/WSShopping.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "E96B3699-3E9B-4EFC-A66C-6EA87B576967"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/WSShopping/BaseView/BaseCollectionView.swift
+++ b/WSShopping/BaseView/BaseCollectionView.swift
@@ -1,0 +1,67 @@
+//
+//  BaseCollectionViewCell.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 1/17/25.
+//
+
+import UIKit
+import SnapKit
+
+class BaseCollectionView: BaseView {
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout())
+    
+    func collectionViewLayout() -> UICollectionViewFlowLayout {
+        
+        let sectionInsect: CGFloat = 10
+        let cellSpacing: CGFloat = 15
+        let cellWidth: CGFloat = (UIScreen.main.bounds.width - (sectionInsect * 2 + cellSpacing)) / 2
+        
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.itemSize = CGSize(width: cellWidth, height: cellWidth * 1.5)
+        layout.sectionInset = UIEdgeInsets(top: 8, left: sectionInsect, bottom: 8, right: sectionInsect)
+        
+        return layout
+    }
+    
+    func reloadData() {
+        collectionView.reloadData()
+    }
+    
+    func scrollToUp() {
+        collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+    }
+    
+    override func configHierarchy() {
+        self.addSubview(collectionView)
+    }
+    
+    override func configLayout() {
+        collectionView.snp.makeConstraints {
+//            $0.top.equalTo(filterStackview.snp.bottom)
+            $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+    
+    override func configView() {
+        backgroundColor = .clear
+        
+        collectionView.register(SearchResultCollectionViewCell.self, forCellWithReuseIdentifier: SearchResultCollectionViewCell.id)
+    }
+}
+
+//extension BaseCollectionView: UICollectionViewDelegate, UICollectionViewDataSource {
+//    
+//    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+//        return 190
+//    }
+//    
+//    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+//
+//    }
+//    
+//    
+//}

--- a/WSShopping/BaseView/BaseView.swift
+++ b/WSShopping/BaseView/BaseView.swift
@@ -1,0 +1,28 @@
+//
+//  BaseView.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 1/17/25.
+//
+
+import UIKit
+
+class BaseView: UIView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configHierarchy()
+        configLayout()
+        configView()
+    }
+    
+    func configHierarchy() { }
+    func configLayout() { }
+    func configView() { }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WSShopping/View/ViewController/MainViewController.swift
+++ b/WSShopping/View/ViewController/MainViewController.swift
@@ -8,13 +8,13 @@
 import UIKit
 import SnapKit
 
-class MainViewController: UIViewController {
+final class MainViewController: UIViewController {
     
-    let searchbar = UISearchBar()
-    let defaultImage = UIImageView()
-    let defaultLabel = UILabel()
+    private let searchbar = UISearchBar()
+    private let defaultImage = UIImageView()
+    private let defaultLabel = UILabel()
     
-    var homecontent = HomeContent(isValid: true)
+    private var homecontent = HomeContent(isValid: true)
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/WSShopping/View/ViewController/MainViewController.swift
+++ b/WSShopping/View/ViewController/MainViewController.swift
@@ -10,6 +10,8 @@ import SnapKit
 
 final class MainViewController: UIViewController {
     
+    private let viewModel = MainViewModel()
+    
     private let searchbar = UISearchBar()
     private let defaultImage = UIImageView()
     private let defaultLabel = UILabel()
@@ -25,6 +27,7 @@ final class MainViewController: UIViewController {
         configHierarchy()
         configLayout()
         configView()
+        bindData()
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -35,6 +38,30 @@ final class MainViewController: UIViewController {
         homecontent.isValid = true
         defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
         defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
+    }
+    
+    private func bindData() {
+        
+        viewModel.outputCheckValid.lazyBind { isValid in
+
+            let image = self.viewModel.name(isValid ? .validImage : .inValidImage)
+            let text = self.viewModel.name(isValid ? .validText : .InvalidText)
+            self.defaultImage.image = UIImage(named: image)
+            self.defaultLabel.text = text
+            
+            if !isValid {
+                self.searchbar.text = ""
+                self.alertWordCount(message: "2글자 이상 입력해주세요!") {
+                    UIAlertAction(title: "확인", style: .cancel)
+                }
+            } else {
+                let vc = SearchResultViewController()
+                
+                self.navigationController?.pushViewController(vc, animated: true)
+            }
+
+            self.view.endEditing(true)
+        }
     }
     
     @objc
@@ -50,27 +77,29 @@ extension MainViewController: UISearchBarDelegate {
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         
-        guard let keyword = searchBar.text else { return }
+        viewModel.inputSearchText.value = searchBar.text
         
-        switch keyword.count {
-        case 0..<2:
-            homecontent.isValid = false
-            defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
-            defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
-            searchbar.text = ""
-            alertWordCount(message: "2글자 이상 입력해주세요!") {
-                UIAlertAction(title: "확인", style: .cancel)
-            }
-        case 2...:
-            // 화면 전환 시키기 & keyword 다음으로 전달
-            let vc = SearchResultViewController()
-            navigationController?.pushViewController(vc, animated: true)
-            vc.keyword = keyword
-        default:
-            break
-        }
-        
-        view.endEditing(true)
+//        guard let keyword = searchBar.text else { return }
+//        
+//        switch keyword.count {
+//        case 0..<2:
+//            homecontent.isValid = false
+//            defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
+//            defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
+//            searchbar.text = ""
+//            alertWordCount(message: "2글자 이상 입력해주세요!") {
+//                UIAlertAction(title: "확인", style: .cancel)
+//            }
+//        case 2...:
+//            // 화면 전환 시키기 & keyword 다음으로 전달
+//            let vc = SearchResultViewController()
+//            navigationController?.pushViewController(vc, animated: true)
+//            vc.keyword = keyword
+//        default:
+//            break
+//        }
+//        
+//        view.endEditing(true)
     }
 }
 

--- a/WSShopping/View/ViewController/MainViewController.swift
+++ b/WSShopping/View/ViewController/MainViewController.swift
@@ -15,8 +15,6 @@ final class MainViewController: UIViewController {
     private let searchbar = UISearchBar()
     private let defaultImage = UIImageView()
     private let defaultLabel = UILabel()
-    
-    private var homecontent = HomeContent(isValid: true)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,6 +24,7 @@ final class MainViewController: UIViewController {
 
         configHierarchy()
         configLayout()
+        defaultContent()
         configView()
         bindData()
     }
@@ -33,33 +32,29 @@ final class MainViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         
-        searchbar.text = ""
-        
-        homecontent.isValid = true
-        defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
-        defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
+        defaultContent()
     }
     
     private func bindData() {
         
         viewModel.outputCheckValid.lazyBind { isValid in
-
-            let image = self.viewModel.name(isValid ? .validImage : .inValidImage)
-            let text = self.viewModel.name(isValid ? .validText : .InvalidText)
-            self.defaultImage.image = UIImage(named: image)
-            self.defaultLabel.text = text
             
             if !isValid {
-                self.searchbar.text = ""
+                self.defaultImage.image = UIImage(named: self.viewModel.name(.inValidImage))
+                self.defaultLabel.text = self.viewModel.name(.InvalidText)
                 self.alertWordCount(message: "2글자 이상 입력해주세요!") {
                     UIAlertAction(title: "확인", style: .cancel)
                 }
             } else {
-                let vc = SearchResultViewController()
+                self.defaultImage.image = UIImage(named: self.viewModel.name(.validImage))
+                self.defaultLabel.text = self.viewModel.name(.InvalidText)
                 
+                let vc = SearchResultViewController()
+                vc.keyword = self.viewModel.inputSearchText.value ?? ""
                 self.navigationController?.pushViewController(vc, animated: true)
             }
-
+            
+            self.searchbar.text = ""
             self.view.endEditing(true)
         }
     }
@@ -78,28 +73,6 @@ extension MainViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         
         viewModel.inputSearchText.value = searchBar.text
-        
-//        guard let keyword = searchBar.text else { return }
-//        
-//        switch keyword.count {
-//        case 0..<2:
-//            homecontent.isValid = false
-//            defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
-//            defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
-//            searchbar.text = ""
-//            alertWordCount(message: "2글자 이상 입력해주세요!") {
-//                UIAlertAction(title: "확인", style: .cancel)
-//            }
-//        case 2...:
-//            // 화면 전환 시키기 & keyword 다음으로 전달
-//            let vc = SearchResultViewController()
-//            navigationController?.pushViewController(vc, animated: true)
-//            vc.keyword = keyword
-//        default:
-//            break
-//        }
-//        
-//        view.endEditing(true)
     }
 }
 
@@ -128,7 +101,7 @@ extension MainViewController: ShoppingConfigure {
         
         defaultLabel.snp.makeConstraints {
             $0.centerX.equalTo(defaultImage)
-            $0.top.equalTo(defaultImage.snp.bottom).offset(homecontent.isValid ? -20 : -60)
+            $0.top.equalTo(defaultImage.snp.bottom).offset(-30)
             $0.width.equalTo(300)
         }
     }
@@ -142,15 +115,16 @@ extension MainViewController: ShoppingConfigure {
         searchbar.searchBarStyle = .minimal
         searchbar.placeholder = HomeContent.placeholder
         
-        defaultImage.image = UIImage(named: homecontent.isValidCheck(content: Contents.imageName))
         defaultImage.contentMode = .scaleAspectFit
         
-        defaultLabel.text = homecontent.isValidCheck(content: Contents.labelText)
         defaultLabel.textColor = .label
         defaultLabel.font = .systemFont(ofSize: 15, weight: .semibold)
         defaultLabel.textAlignment = .center
         defaultLabel.numberOfLines = 1
     }
     
-    
+    private func defaultContent() {
+        defaultImage.image = UIImage(named: viewModel.name(.validImage))
+        defaultLabel.text = viewModel.name(.InvalidText)
+    }
 }

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -40,7 +40,6 @@ class SearchResultViewController: UIViewController {
     
     let buttonTitle = StrokeButton.titleList
     
-
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -10,6 +10,9 @@ import Alamofire
 import Kingfisher
 import SnapKit
 
+// BaseView는 주말에 재도전..
+// 네트워크 통신 오류 해결은 print를 잘 찍어보자... 하루를 다 써버린...
+
 class SearchResultViewController: UIViewController {
     
     lazy var resultCountLabel = ResultLabel(title: "", size: 15, weight: .bold, color: .systemGreen)
@@ -69,7 +72,7 @@ class SearchResultViewController: UIViewController {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         layout.itemSize = CGSize(width: cellWidth, height: cellWidth * 1.5)
-        layout.sectionInset = UIEdgeInsets(top: 8, left: sectionInsect, bottom: 8, right: sectionInsect)
+        layout.sectionInset = UIEdgeInsets(top: 2, left: sectionInsect, bottom: 2, right: sectionInsect)
         
         return layout
     }

--- a/WSShopping/ViewModel/MainViewModel.swift
+++ b/WSShopping/ViewModel/MainViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  MainViewModel.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 2/6/25.
+//
+
+import Foundation
+
+final class MainViewModel {
+    
+    
+}

--- a/WSShopping/ViewModel/MainViewModel.swift
+++ b/WSShopping/ViewModel/MainViewModel.swift
@@ -7,7 +7,48 @@
 
 import Foundation
 
+enum HomeContents: String {
+    case validImage = "shopping"
+    case inValidImage = "nono"
+    case validText = "이것도 사고 저것도 살래 :>"
+    case InvalidText = "2글자 이상으로 검색해주세요!"
+}
+
 final class MainViewModel {
     
+    let inputSearchText: Observable<String?> = Observable("")
     
+    let outputCheckValid: Observable<Bool> = Observable(true)
+    
+    init() {
+        
+        inputSearchText.lazyBind { [weak self] text in
+            self?.checkKeywordValid()
+        }
+    }
+    
+    private func checkKeywordValid() {
+        
+        guard let keyword = inputSearchText.value else {
+            print("keyword nil")
+            return
+        }
+        
+        switch keyword.count {
+        case ..<2:
+            outputCheckValid.value = false
+        case 2...:
+            outputCheckValid.value = true
+        default:
+            print("\(keyword.count) error")
+            break
+        }
+    }
+}
+
+extension MainViewModel {
+    
+    func name(_ type: HomeContents) -> String {
+        return type.rawValue
+    }
 }

--- a/WSShopping/ViewModel/Observable.swift
+++ b/WSShopping/ViewModel/Observable.swift
@@ -1,0 +1,34 @@
+//
+//  Observar.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 2/6/25.
+//
+
+import Foundation
+
+final class Observable<T> {
+    
+    var closure: ((T) -> ())?
+    
+    var value: T {
+        didSet {
+            closure?(value)
+        }
+    }
+    
+    init(_ value: T) {
+        self.value = value
+    }
+    
+    // 먼저 설정된 값부터 감시하는 메서드
+    func bind(_ closure: @escaping (T) -> ()) {
+        closure(value)
+        self.closure = closure
+    }
+    
+    // 다음 행동이 일어난 후부터 감시하는 메서드
+    func lazyBind(_ closure: @escaping (T) -> ()) {
+        self.closure = closure
+    }
+}


### PR DESCRIPTION
## 한 일
1. 기존 메인화면의 ViewController 내부에 혼재되어 있는 뷰와 기능 로직 분리
- ViewModel 활용해 Observable을 활용하여 분리