### PR TITLE
[Refactor] #21 전체적으로 RxSwift 도입하여 구성 수정하고 MVVM 패턴에도 적용

### DIFF
--- a/WSShopping.xcodeproj/project.pbxproj
+++ b/WSShopping.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4314DDAC2D6D8FB3007EBA65 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 4314DDAB2D6D8FB3007EBA65 /* RxCocoa */; };
+		4314DDAE2D6D8FB3007EBA65 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4314DDAD2D6D8FB3007EBA65 /* RxSwift */; };
 		4350E1502D37947F00670D84 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 4350E14F2D37947F00670D84 /* .gitignore */; };
 		4350E17F2D379F8400670D84 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4350E17E2D379F8400670D84 /* SnapKit */; };
 		4350E1822D379F9A00670D84 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 4350E1812D379F9A00670D84 /* Alamofire */; };
@@ -46,6 +48,8 @@
 			files = (
 				4350E1852D379FAA00670D84 /* Kingfisher in Frameworks */,
 				4350E17F2D379F8400670D84 /* SnapKit in Frameworks */,
+				4314DDAE2D6D8FB3007EBA65 /* RxSwift in Frameworks */,
+				4314DDAC2D6D8FB3007EBA65 /* RxCocoa in Frameworks */,
 				4350E1822D379F9A00670D84 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -93,6 +97,8 @@
 				4350E17E2D379F8400670D84 /* SnapKit */,
 				4350E1812D379F9A00670D84 /* Alamofire */,
 				4350E1842D379FAA00670D84 /* Kingfisher */,
+				4314DDAB2D6D8FB3007EBA65 /* RxCocoa */,
+				4314DDAD2D6D8FB3007EBA65 /* RxSwift */,
 			);
 			productName = WSShopping;
 			productReference = 4350E1372D3793F800670D84 /* WSShopping.app */;
@@ -126,6 +132,7 @@
 				4350E17D2D379F8400670D84 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				4350E1802D379F9A00670D84 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				4350E1832D379FAA00670D84 /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				4314DDAA2D6D8FB3007EBA65 /* XCRemoteSwiftPackageReference "RxSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4350E1382D3793F800670D84 /* Products */;
@@ -368,6 +375,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4314DDAA2D6D8FB3007EBA65 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.9.0;
+			};
+		};
 		4350E17D2D379F8400670D84 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -395,6 +410,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4314DDAB2D6D8FB3007EBA65 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4314DDAA2D6D8FB3007EBA65 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		4314DDAD2D6D8FB3007EBA65 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4314DDAA2D6D8FB3007EBA65 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
 		4350E17E2D379F8400670D84 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4350E17D2D379F8400670D84 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/WSShopping.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WSShopping.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed55cc596a4e4cab36b1d30ff56401dba0b9b1bffeb22a1780c061b42e8d9248",
+  "originHash" : "45451429ca0f11a98b7afda1931e13ca4e3cc6dda37d1e0f4e4391f7a1e3e4e7",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "e6749919f9761d573d37a7d7e78b1b854c191d7f",
         "version" : "8.1.3"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift",
+      "state" : {
+        "revision" : "5dd1907d64f0d36f158f61a466bab75067224893",
+        "version" : "6.9.0"
       }
     },
     {

--- a/WSShopping/CustomView/StrokeButton.swift
+++ b/WSShopping/CustomView/StrokeButton.swift
@@ -7,32 +7,57 @@
 
 import UIKit
 
-class StrokeButton: UIButton {
+final class StrokeButton: UIButton {
     
-    static let titleList = ["정확도", "날짜순", "가격높은순", "가격낮은순"]
+    override var isSelected: Bool {
+        didSet {
+
+            self.configuration?.baseBackgroundColor = isSelected ? .label : .systemBackground
+            self.configuration?.baseForegroundColor = isSelected ? .systemBackground : .label
+
+        }
+    }
+
+    init(sort: Sort, isSelected: Bool) {
+        super.init(frame: .zero)
+        
+        self.isSelected = isSelected
+        configButton(sort: sort)
+    }
     
-    func configButton(title: String, isTapped: Bool) {
+    private func configButton(sort: Sort) {
         
         let container = AttributeContainer().font(.systemFont(ofSize: 14, weight: .regular))
         
         var config = Configuration.filled()
         config.cornerStyle = .medium
-        config.title = title
-        config.attributedTitle = AttributedString(title, attributes: container)
-        config.baseBackgroundColor = isTapped ? .label : .systemBackground
+        config.attributedTitle = AttributedString(sort.rawValue, attributes: container)
+        config.baseBackgroundColor = isSelected ? .label : .systemBackground
         config.background.strokeColor = .label
         config.background.strokeWidth = 1
-        config.baseForegroundColor = isTapped ? .systemBackground : .label
+        config.baseForegroundColor = isSelected ? .systemBackground : .label
         
         self.configuration = config
     }
-
-    init(title: String, isTapped: Bool) {
-        super.init(frame: .zero)
-        configButton(title: title, isTapped: isTapped)
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        
+        isSelected.toggle()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension StrokeButton {
+    
+    enum Sort: String, CaseIterable {
+        case 정확도
+        case 날짜순
+        case 가격높은순
+        case 가격낮은순
     }
 }

--- a/WSShopping/CustomView/StrokeButton.swift
+++ b/WSShopping/CustomView/StrokeButton.swift
@@ -52,12 +52,20 @@ final class StrokeButton: UIButton {
     }
 }
 
-extension StrokeButton {
     
-    enum Sort: String, CaseIterable {
-        case 정확도
-        case 날짜순
-        case 가격높은순
-        case 가격낮은순
+enum Sort: String, CaseIterable {
+    case 정확도
+    case 날짜순
+    case 가격높은순
+    case 가격낮은순
+    
+    var query: String {
+        switch self {
+        case .정확도: return "sim"
+        case .날짜순: return "date"
+        case .가격높은순: return "dsc"
+        case .가격낮은순: return "asc"
+        }
     }
 }
+

--- a/WSShopping/Extension/UIViewController+Extension.swift
+++ b/WSShopping/Extension/UIViewController+Extension.swift
@@ -20,4 +20,13 @@ extension UIViewController {
         present(message, animated: true)
         
     }
+    
+    func alertError(message: String) {
+        let message = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        
+        let okay = UIAlertAction(title: "확인", style: .cancel)
+        message.addAction(okay)
+        
+        present(message, animated: true)
+    }
 }

--- a/WSShopping/Model/AlamofireManager.swift
+++ b/WSShopping/Model/AlamofireManager.swift
@@ -5,7 +5,9 @@
 //  Created by Lee Wonsun on 1/16/25.
 //
 
-import UIKit
+import Foundation
+import RxSwift
+import RxCocoa
 import Alamofire
 
 final class AlamofireManager {
@@ -13,6 +15,33 @@ final class AlamofireManager {
     static let shared = AlamofireManager()
     
     private init() { }
+    
+    func callRequestByObservable<T: Decodable>(type: T.Type, api: ApiUrl) -> Single<T> {
+        
+        return Single<T>.create { value in
+            
+            AF.request(
+                api.baseUrl,
+                method: api.method,
+                parameters: api.parameters,
+                encoding: URLEncoding(destination: .queryString),
+                headers: api.header
+            ).responseDecodable(of: T.self) { response in
+                
+                switch response.result {
+                case .success(let result):
+                    value(.success(result))
+                case .failure(let error):
+                    value(.failure(error))
+                }
+            }
+            
+            return Disposables.create {
+                print("통신 끝")
+            }
+        }
+        
+    }
     
     func callRequest<T: Decodable>(_ type: T.Type, api: ApiUrl,  completionHandler: @escaping (Result<T, AFError>) -> ()) {
         

--- a/WSShopping/Model/ShoppingError.swift
+++ b/WSShopping/Model/ShoppingError.swift
@@ -1,0 +1,25 @@
+//
+//  ShoppingError.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 2/26/25.
+//
+
+import Foundation
+
+enum ShoppingError: Error {
+    case invalidURL
+    case unknownResponse
+    case statudError(code: Int)
+    
+    var message: String {
+        switch self {
+        case .invalidURL:
+            return "잘못된 URL 접근입니다."
+        case .unknownResponse:
+            return "unknownedResponse Error"
+        case .statudError(let code):
+            return "error \(code): status Error"
+        }
+    }
+}

--- a/WSShopping/Protocol/BaseViewModel.swift
+++ b/WSShopping/Protocol/BaseViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  BaseViewModel.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 2/25/25.
+//
+
+import Foundation
+import RxSwift
+
+protocol BaseViewModel: AnyObject {
+    associatedtype Input
+    associatedtype Output
+    
+    var disposeBag: DisposeBag { get set }
+    
+    func transform(input: Input) -> Output
+}

--- a/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
+++ b/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 import SnapKit
 
 final class SearchResultCollectionViewCell: UICollectionViewCell {
@@ -81,5 +82,20 @@ extension SearchResultCollectionViewCell {
             $0.top.equalTo(titleLabel.snp.bottom).offset(5)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(8)
         }
+    }
+    
+    func configureCell(url: String, mallName: String, title: String, price: String) {
+        let processor = DownsamplingImageProcessor(size: CGSize(width: thumnailImageView.frame.width, height: thumnailImageView.frame.height))
+        
+        thumnailImageView.kf.setImage(with: URL(string: url),
+                                           options: [
+                                            .processor(processor),
+                                            .scaleFactor(UIScreen.main.scale),
+                                            .cacheOriginalImage
+                                           ])
+        thumnailImageView.contentMode = .scaleAspectFill
+        mallNameLabel.text = mallName
+        titleLabel.text = title.escapingHTML
+        priceLabel.text = price + "원"
     }
 }

--- a/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
+++ b/WSShopping/View/CollectionViewCell/SearchResultCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class SearchResultCollectionViewCell: UICollectionViewCell {
+final class SearchResultCollectionViewCell: UICollectionViewCell {
     
     static let id = "SearchResultCollectionViewCell"
     

--- a/WSShopping/View/ViewController/MainViewController.swift
+++ b/WSShopping/View/ViewController/MainViewController.swift
@@ -49,9 +49,7 @@ final class MainViewController: UIViewController {
                 self.defaultImage.image = UIImage(named: self.viewModel.name(.validImage))
                 self.defaultLabel.text = self.viewModel.name(.InvalidText)
                 
-                let vc = SearchResultViewController()
-                vc.viewModel.inputQuery.value.0 = self.viewModel.inputSearchText.value ?? ""
-                print(vc.viewModel.inputQuery.value.0)
+                let vc = SearchResultViewController(keyword: self.viewModel.inputSearchText.value ?? "")
                 self.navigationController?.pushViewController(vc, animated: true)
             }
             

--- a/WSShopping/View/ViewController/MainViewController.swift
+++ b/WSShopping/View/ViewController/MainViewController.swift
@@ -7,26 +7,32 @@
 
 import UIKit
 import SnapKit
+import RxSwift
+import RxCocoa
 
 final class MainViewController: UIViewController {
     
     private let viewModel = MainViewModel()
+    private let disposeBag = DisposeBag()
     
     private let searchbar = UISearchBar()
     private let defaultImage = UIImageView()
     private let defaultLabel = UILabel()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-        view.addGestureRecognizer(tap)
-
         configHierarchy()
         configLayout()
         defaultContent()
         configView()
         bindData()
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        
+        view.endEditing(true)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -37,50 +43,40 @@ final class MainViewController: UIViewController {
     
     private func bindData() {
         
-        viewModel.outputCheckValid.lazyBind { isValid in
-            
-            if !isValid {
-                self.defaultImage.image = UIImage(named: self.viewModel.name(.inValidImage))
-                self.defaultLabel.text = self.viewModel.name(.InvalidText)
-                self.alertWordCount(message: "2글자 이상 입력해주세요!") {
-                    UIAlertAction(title: "확인", style: .cancel)
+        let input = MainViewModel.Input(
+            tappedSearchButton: searchbar.rx.searchButtonClicked,
+            searchKeyword: searchbar.rx.text
+        )
+        let output = viewModel.transform(input: input)
+
+        output.isValid
+            .drive(with: self) { this, value in
+                switch value {
+                case true:
+                    this.defaultImage.image = UIImage(named: this.viewModel.name(.validImage))
+                    this.defaultLabel.text = this.viewModel.name(.InvalidText)
+                    
+                    let vc = SearchResultViewController(keyword: this.searchbar.text ?? "")
+                    this.navigationController?.pushViewController(vc, animated: true)
+                case false:
+                    this.defaultImage.image = UIImage(named: this.viewModel.name(.inValidImage))
+                    this.defaultLabel.text = this.viewModel.name(.InvalidText)
+                    this.alertWordCount(message: "2글자 이상 입력해주세요!") {
+                        UIAlertAction(title: "확인", style: .cancel)
+                    }
                 }
-            } else {
-                self.defaultImage.image = UIImage(named: self.viewModel.name(.validImage))
-                self.defaultLabel.text = self.viewModel.name(.InvalidText)
                 
-                let vc = SearchResultViewController(keyword: self.viewModel.inputSearchText.value ?? "")
-                self.navigationController?.pushViewController(vc, animated: true)
+                this.searchbar.text = ""
+                this.view.endEditing(true)
             }
-            
-            self.searchbar.text = ""
-            self.view.endEditing(true)
-        }
-    }
-    
-    @objc
-    func dismissKeyboard() {
-        view.endEditing(true)
-    }
-    
-
-}
-
-// MARK: - 서치바 관련 액션
-extension MainViewController: UISearchBarDelegate {
-    
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        
-        viewModel.inputSearchText.value = searchBar.text
+            .disposed(by: disposeBag)
     }
 }
-
 
 // MARK: - 레이아웃 및 속성 설정
 extension MainViewController: ShoppingConfigure {
     func configHierarchy() {
-        searchbar.delegate = self
-    
+        
         view.addSubview(searchbar)
         view.addSubview(defaultImage)
         view.addSubview(defaultLabel)

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -88,14 +88,13 @@ final class SearchResultViewController: UIViewController {
                 }
                 .disposed(by: disposeBag)
         
-        // TODO: 스크롤 업 타이밍 잡는 시점은 어디로...?
-//        output.startPage
-//            .map { $0 == 1 }
-//            .drive(with: self) { this, value in
-// 
-//                this.collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
-//            }
-//            .disposed(by: disposeBag)
+        output.startPage
+            .map { $0 == 1 }
+            .debug("scroll")
+            .drive(with: self, onNext: { this, value in
+                this.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
+            })
+            .disposed(by: disposeBag)
         
         output.errorMessage
             .bind(with: self) { this, message in

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -25,33 +25,12 @@ final class SearchResultViewController: UIViewController {
         
         return stackview
     }()
+
     
-//    var start = 1
-//    var keyword = ""
-//    var sortName = "sim"
-//    var total = 0
-//    var isEnd = false
-//    var list: [ShoppingDetail] = [] {
-//        didSet {
-//            self.collectionView.reloadData()
-//        }
-//    }
-    
-    let buttonTitle = StrokeButton.titleList
+    let buttonTitle = StrokeButton.Sort.allCases
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        for index in 0...3 {
-
-            if index == 0 {
-                filteringButtons.append(StrokeButton(title: buttonTitle[index], isTapped: true))
-            } else {
-                filteringButtons.append(StrokeButton(title: buttonTitle[index], isTapped: false))
-            }
-            
-            filteringButtons[index].tag = index
-        }
 
         configHierarchy()
         configLayout()
@@ -90,67 +69,58 @@ final class SearchResultViewController: UIViewController {
         return layout
     }
     
-//    func callRequest() {
-//        
-//        AlamofireManager.shared.getShoppingResult(keyword: keyword, sortName: sortName, start: start) { value in
-//
-//            if self.start == 1 {
-//                self.total = value.total
-//                self.resultCountLabel.text = String(self.total.formatted()) + "개의 검색결과"
-//                self.list = value.items
-//            } else {
-//                self.list.append(contentsOf: value.items)
-//            }
-//        }
-//        
-//    }
-    
     @objc
     func filteringButtonTapped(button: UIButton) {
  
-        guard let title = button.titleLabel?.text else { return }
+//        guard let title = button.titleLabel?.text else { return }
         
-        switch title {
-        case StrokeButton.titleList[0]:
-            viewModel.inputQuery.value.2 = 1
-            viewModel.inputQuery.value.1 = "sim"
-            filteringProcess(button: button)
-        case StrokeButton.titleList[1]:
-            viewModel.inputQuery.value.2 = 1
-            viewModel.inputQuery.value.1  = "date"
-            filteringProcess(button: button)
-        case StrokeButton.titleList[2]:
-            viewModel.inputQuery.value.2 = 1
-            viewModel.inputQuery.value.1  = "dsc"
-            filteringProcess(button: button)
-        case StrokeButton.titleList[3]:
-            viewModel.inputQuery.value.2 = 1
-            viewModel.inputQuery.value.1  = "asc"
-            filteringProcess(button: button)
+//        switch title {
+//        case StrokeButton.titleList[0]:
+//            viewModel.inputQuery.value.2 = 1
+//            viewModel.inputQuery.value.1 = "sim"
+//            filteringProcess(button: button)
+//        case StrokeButton.titleList[1]:
+//            viewModel.inputQuery.value.2 = 1
+//            viewModel.inputQuery.value.1  = "date"
+//            filteringProcess(button: button)
+//        case StrokeButton.titleList[2]:
+//            viewModel.inputQuery.value.2 = 1
+//            viewModel.inputQuery.value.1  = "dsc"
+//            filteringProcess(button: button)
+//        case StrokeButton.titleList[3]:
+//            viewModel.inputQuery.value.2 = 1
+//            viewModel.inputQuery.value.1  = "asc"
+//            filteringProcess(button: button)
+//        default:
+//            print("title error")
+//            break
+//        }
+        
+        filteringButtons.forEach {
+            $0.isSelected = false
+        }
+        
+        let tag = button.tag
+  
+        switch tag {
+        case 0:
+            
+        case 1:
+            
+        case 2:
+            
+        case 3:
+            
         default:
-            print("title error")
+            print("button title error")
             break
         }
+        
     }
     
     func filteringProcess(button: UIButton) {
         viewModel.inputRequest.value = ()
-        reloadButtonColor(button: button)
         scrollToUp()
-    }
-    
-    // 새로 생각해본 로직 - 중복되게 안할 수 있는 방법
-    func reloadButtonColor(button: UIButton) {
-        
-        for index in 0...3 {
-            if index == button.tag {
-                filteringButtons[index].configuration?.baseBackgroundColor = .label
-                filteringButtons[index].configuration?.baseForegroundColor = .systemBackground
-            } else {
-                filteringButtons[index].configuration?.baseBackgroundColor = .systemBackground
-                filteringButtons[index].configuration?.baseForegroundColor = .label
-            }
-        }
     }
     
     func scrollToUp() {
@@ -246,6 +216,17 @@ extension SearchResultViewController: ShoppingConfigure {
     func configView() {
         view.backgroundColor = .systemBackground
         navigationItem.title = viewModel.inputQuery.value.0
+        
+        for index in 0...3 {
+
+            if index == 0 {
+                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: true))
+            } else {
+                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: false))
+            }
+            
+            filteringButtons[index].tag = index
+        }
         
         for index in 0...3 {
             filteringButtons[index].addTarget(self, action: #selector(filteringButtonTapped), for: .touchUpInside)

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 
 final class SearchResultViewController: UIViewController {
     
-    let viewModel = SearchResultViewModel()
+    let viewModel: SearchResultViewModel
     
     lazy var resultCountLabel = ResultLabel(title: "", size: 15, weight: .bold, color: .systemGreen)
     var filteringButtons: [UIButton] = []
@@ -29,6 +29,12 @@ final class SearchResultViewController: UIViewController {
     
     let buttonTitle = StrokeButton.Sort.allCases
     
+    init(keyword: String) {
+        viewModel = SearchResultViewModel(keyword: keyword)
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -39,6 +45,11 @@ final class SearchResultViewController: UIViewController {
     }
     
     private func bindData() {
+        
+        let input = SearchResultViewModel.Input()
+        let output = viewModel.transform(input: input)
+        
+        
         viewModel.outputRequest.bind { data in
             // start = 1 일 때 데이터 리로드 하도록
             self.viewModel.outputReloadAction.value = {
@@ -100,21 +111,21 @@ final class SearchResultViewController: UIViewController {
             $0.isSelected = false
         }
         
-        let tag = button.tag
-  
-        switch tag {
-        case 0:
-            
-        case 1:
-            
-        case 2:
-            
-        case 3:
-            
-        default:
-            print("button title error")
-            break
-        }
+//        let tag = button.tag
+//  
+//        switch tag {
+//        case 0:
+//            
+//        case 1:
+//            
+//        case 2:
+//            
+//        case 3:
+//            
+//        default:
+//            print("button title error")
+//            break
+//        }
         
     }
     
@@ -127,6 +138,10 @@ final class SearchResultViewController: UIViewController {
         collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
     }
 
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }
 
 // MARK: - collectionView 설정
@@ -183,6 +198,17 @@ extension SearchResultViewController: ShoppingConfigure {
         collectionView.dataSource = self
         collectionView.prefetchDataSource = self
         
+        for index in 0...3 {
+
+            if index == 0 {
+                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: true))
+            } else {
+                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: false))
+            }
+            
+            filteringButtons[index].tag = index
+        }
+        
         view.addSubview(resultCountLabel)
         view.addSubview(filterStackview)
         for index in 0...3 {
@@ -216,17 +242,6 @@ extension SearchResultViewController: ShoppingConfigure {
     func configView() {
         view.backgroundColor = .systemBackground
         navigationItem.title = viewModel.inputQuery.value.0
-        
-        for index in 0...3 {
-
-            if index == 0 {
-                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: true))
-            } else {
-                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: false))
-            }
-            
-            filteringButtons[index].tag = index
-        }
         
         for index in 0...3 {
             filteringButtons[index].addTarget(self, action: #selector(filteringButtonTapped), for: .touchUpInside)

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -29,9 +29,6 @@ final class SearchResultViewController: UIViewController {
         return stackview
     }()
 
-    
-    let buttonTitle = Sort.allCases
-    
     init(keyword: String) {
         viewModel = SearchResultViewModel(keyword: keyword)
         
@@ -90,71 +87,12 @@ final class SearchResultViewController: UIViewController {
                 }
                 .disposed(by: disposeBag)
         
-        
-        filteringButtons.forEach { button in
-            let list = button.rx.tap
-                .map {
-                    self.filteringButtons.forEach {
-                        $0.isSelected = false
-                    }
-                }
-                .map { button.tag }
-            
-            list
-                .bind(with: self) { this, tag in
-                    
-                    switch tag {
-                    case 0:
-                        print("0")
-                    case 1:
-                        print("1")
-                    case 2:
-                        print("2")
-                    case 3:
-                        print("3")
-                    default:
-                        print("button title error")
-                        break
-                    }
-                }
-                .disposed(by: disposeBag)
-        }
-        
-        //        switch title {
-        //        case StrokeButton.titleList[0]:
-        //            viewModel.inputQuery.value.2 = 1
-        //            viewModel.inputQuery.value.1 = "sim"
-        //            filteringProcess(button: button)
-        //        case StrokeButton.titleList[1]:
-        //            viewModel.inputQuery.value.2 = 1
-        //            viewModel.inputQuery.value.1  = "date"
-        //            filteringProcess(button: button)
-        //        case StrokeButton.titleList[2]:
-        //            viewModel.inputQuery.value.2 = 1
-        //            viewModel.inputQuery.value.1  = "dsc"
-        //            filteringProcess(button: button)
-        //        case StrokeButton.titleList[3]:
-        //            viewModel.inputQuery.value.2 = 1
-        //            viewModel.inputQuery.value.1  = "asc"
-        //            filteringProcess(button: button)
-        //        default:
-        //            print("title error")
-        //            break
-        //        }
-
-        
-        //=================이전코드========================
-        
-//        viewModel.outputRequest.bind { data in
-//            // start = 1 일 때 데이터 리로드 하도록
-//            self.viewModel.outputReloadAction.value = {
-//                self.collectionView.reloadData()
-//            }()
-//        }
-//        
-//        viewModel.outputStart.lazyBind { _ in
-//            self.collectionView.reloadData()
-//        }
+        output.startPage
+            .map { $0 == 1 }
+            .drive(with: self) { this, value in
+                this.collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+            }
+            .disposed(by: disposeBag)
     }
     
     func collectionViewLayout() -> UICollectionViewFlowLayout {
@@ -212,9 +150,9 @@ extension SearchResultViewController: ShoppingConfigure {
         for index in 0...3 {
 
             if index == 0 {
-                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: true))
+                filteringButtons.append(StrokeButton(sort: viewModel.buttonTitle[index], isSelected: true))
             } else {
-                filteringButtons.append(StrokeButton(sort: buttonTitle[index], isSelected: false))
+                filteringButtons.append(StrokeButton(sort: viewModel.buttonTitle[index], isSelected: false))
             }
             
             filteringButtons[index].tag = index

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -63,7 +63,8 @@ final class SearchResultViewController: UIViewController {
         }
         
         let input = SearchResultViewModel.Input(
-            buttonTag: buttons
+            buttonTag: buttons,
+            prefetchIndexPath: collectionView.rx.prefetchItems
         )
         let output = viewModel.transform(input: input)
         
@@ -87,10 +88,18 @@ final class SearchResultViewController: UIViewController {
                 }
                 .disposed(by: disposeBag)
         
-        output.startPage
-            .map { $0 == 1 }
-            .drive(with: self) { this, value in
-                this.collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+        // TODO: 스크롤 업 타이밍 잡는 시점은 어디로...?
+//        output.startPage
+//            .map { $0 == 1 }
+//            .drive(with: self) { this, value in
+// 
+//                this.collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+//            }
+//            .disposed(by: disposeBag)
+        
+        output.errorMessage
+            .drive(with: self) { this, message in
+                this.alertError(message: message)
             }
             .disposed(by: disposeBag)
     }
@@ -107,15 +116,6 @@ final class SearchResultViewController: UIViewController {
         layout.sectionInset = UIEdgeInsets(top: 2, left: sectionInsect, bottom: 2, right: sectionInsect)
         
         return layout
-    }
-    
-    func filteringProcess(button: UIButton) {
-//        viewModel.inputRequest.value = ()
-        scrollToUp()
-    }
-    
-    func scrollToUp() {
-        collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
     }
 
     @available(*, unavailable)

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -98,7 +98,7 @@ final class SearchResultViewController: UIViewController {
 //            .disposed(by: disposeBag)
         
         output.errorMessage
-            .drive(with: self) { this, message in
+            .bind(with: self) { this, message in
                 this.alertError(message: message)
             }
             .disposed(by: disposeBag)

--- a/WSShopping/ViewModel/Observable.swift
+++ b/WSShopping/ViewModel/Observable.swift
@@ -7,28 +7,28 @@
 
 import Foundation
 
-//final class Observable<T> {
-//    
-//    var closure: ((T) -> ())?
-//    
-//    var value: T {
-//        didSet {
-//            closure?(value)
-//        }
-//    }
-//    
-//    init(_ value: T) {
-//        self.value = value
-//    }
-//    
-//    // 먼저 설정된 값부터 감시하는 메서드
-//    func bind(_ closure: @escaping (T) -> ()) {
-//        closure(value)
-//        self.closure = closure
-//    }
-//    
-//    // 다음 행동이 일어난 후부터 감시하는 메서드
-//    func lazyBind(_ closure: @escaping (T) -> ()) {
-//        self.closure = closure
-//    }
-//}
+final class Observable<T> {
+    
+    var closure: ((T) -> ())?
+    
+    var value: T {
+        didSet {
+            closure?(value)
+        }
+    }
+    
+    init(_ value: T) {
+        self.value = value
+    }
+    
+    // 먼저 설정된 값부터 감시하는 메서드
+    func bind(_ closure: @escaping (T) -> ()) {
+        closure(value)
+        self.closure = closure
+    }
+    
+    // 다음 행동이 일어난 후부터 감시하는 메서드
+    func lazyBind(_ closure: @escaping (T) -> ()) {
+        self.closure = closure
+    }
+}

--- a/WSShopping/ViewModel/Observable.swift
+++ b/WSShopping/ViewModel/Observable.swift
@@ -7,28 +7,28 @@
 
 import Foundation
 
-final class Observable<T> {
-    
-    var closure: ((T) -> ())?
-    
-    var value: T {
-        didSet {
-            closure?(value)
-        }
-    }
-    
-    init(_ value: T) {
-        self.value = value
-    }
-    
-    // 먼저 설정된 값부터 감시하는 메서드
-    func bind(_ closure: @escaping (T) -> ()) {
-        closure(value)
-        self.closure = closure
-    }
-    
-    // 다음 행동이 일어난 후부터 감시하는 메서드
-    func lazyBind(_ closure: @escaping (T) -> ()) {
-        self.closure = closure
-    }
-}
+//final class Observable<T> {
+//    
+//    var closure: ((T) -> ())?
+//    
+//    var value: T {
+//        didSet {
+//            closure?(value)
+//        }
+//    }
+//    
+//    init(_ value: T) {
+//        self.value = value
+//    }
+//    
+//    // 먼저 설정된 값부터 감시하는 메서드
+//    func bind(_ closure: @escaping (T) -> ()) {
+//        closure(value)
+//        self.closure = closure
+//    }
+//    
+//    // 다음 행동이 일어난 후부터 감시하는 메서드
+//    func lazyBind(_ closure: @escaping (T) -> ()) {
+//        self.closure = closure
+//    }
+//}

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -12,7 +12,8 @@ import RxSwift
 final class SearchResultViewModel: BaseViewModel {
     
     struct Input {
-        //
+        // 필터링 버튼의 태그를 전달받기 (버튼탭을 통해서)
+        let buttonTag: [Observable<Int>]
     }
     
     struct Output {
@@ -23,36 +24,25 @@ final class SearchResultViewModel: BaseViewModel {
     var disposeBag: DisposeBag = DisposeBag()
     
     let keyword: String
+    var sort: String
+    var start: Int
 
     typealias Query = (String, String, Int)
-    var inputQuery: Observable<Query> = Observable(("", "sim", 1))
-    let inputRequest: Observable<Void> = Observable(())
-    let inputPrefetch: Observable<[IndexPath]> = Observable([])
-    
-    let outputRequest: Observable<[ShoppingDetail?]> = Observable([])
-    let outputReloadAction: Observable<Void> = Observable(())
-    var outputStart: Observable<Int> = Observable(1)
-    let outputTotal: Observable<Int> = Observable(0)
-    var outputIsEnd: Observable<Bool> = Observable(false)
+//    var inputQuery: Observable<Query> = Observable(("", "sim", 1))
+//    let inputRequest: Observable<Void> = Observable(())
+//    let inputPrefetch: Observable<[IndexPath]> = Observable([])
+//    
+//    let outputRequest: Observable<[ShoppingDetail?]> = Observable([])
+//    let outputReloadAction: Observable<Void> = Observable(())
+//    var outputStart: Observable<Int> = Observable(1)
+//    let outputTotal: Observable<Int> = Observable(0)
+//    var outputIsEnd: Observable<Bool> = Observable(false)
     
     init(keyword: String) {
         
         self.keyword = keyword
-        
-//        AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: keyword, sortName: "sim", start: 1))
-//            .catch { error in
-//                
-//                print("shopping error", error)
-//                
-//                let data = Shopping(total: 0, items: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
-//                return Single.just(data)
-//            }
-//            .debug("shopping")
-//            .asObservable()
-//            .bind(with: self) { this, value in
-//                dump(value)
-//            }
-//            .disposed(by: disposeBag)
+        self.sort = Sort.정확도.query
+        self.start = 1
     }
     
     func transform(input: Input) -> Output {
@@ -61,7 +51,7 @@ final class SearchResultViewModel: BaseViewModel {
         let shoppingDetail = BehaviorRelay(value: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
         
         // MARK: 화면 진입 시 첫 통신
-        AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: keyword, sortName: Sort.정확도.query, start: 1))
+        AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: keyword, sortName: sort, start: start))
             .catch { error in
                 
                 print("shopping error", error)
@@ -77,25 +67,55 @@ final class SearchResultViewModel: BaseViewModel {
             }
             .disposed(by: disposeBag)
         
+        // MARK: 전달 받은 버튼의 태그값 활용
+        input.buttonTag.forEach { value in
+            value
+                .bind(with: self) { this, tag in
+                    let sortList = Sort.allCases.map { $0.query }
+                    this.sort = sortList[tag]
+                    this.start = 1
+                    
+                    AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: this.keyword, sortName: this.sort, start: this.start))
+                        .catch { error in
+                            
+                            print("shopping error", error)
+                            
+                            let data = Shopping(total: 0, items: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
+                            return Single.just(data)
+                        }
+                        .debug("shopping")
+                        .asObservable()
+                        .bind(with: self) { this, value in
+                            shoppingDetail.accept(value.items)
+                            totalCount.accept(value.total)
+                        }
+                        .disposed(by: this.disposeBag)
+                }
+                .disposed(by: disposeBag)
+        }
+            
+            
+//            .disposed(by: disposeBag)
+        
         return Output(
             totalCount: totalCount.asDriver(),
             shoppingDetail: shoppingDetail.asDriver()
         )
     }
     
-    private func checkPagenation(_ itemCount: Int) {
-        
-        let list = outputRequest.value
-        var start = self.outputStart.value
-        var end = self.outputIsEnd.value
-        let total = self.outputTotal.value
-        
-        print("list: ", list.count)
-        if list.count - 5 == itemCount && list.count < total {
-            start += list.count
-            print("start: ", start)
-        } else if list.count >= total {
-            end = true
-        }
-    }
+//    private func checkPagenation(_ itemCount: Int) {
+//        
+//        let list = outputRequest.value
+//        var start = self.outputStart.value
+//        var end = self.outputIsEnd.value
+//        let total = self.outputTotal.value
+//        
+//        print("list: ", list.count)
+//        if list.count - 5 == itemCount && list.count < total {
+//            start += list.count
+//            print("start: ", start)
+//        } else if list.count >= total {
+//            end = true
+//        }
+//    }
 }

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -19,24 +19,15 @@ final class SearchResultViewModel: BaseViewModel {
     struct Output {
         let totalCount: Driver<Int>
         let shoppingDetail: Driver<[ShoppingDetail]>
+        let startPage: Driver<Int>
     }
     
     var disposeBag: DisposeBag = DisposeBag()
+    let buttonTitle = Sort.allCases
     
     let keyword: String
     var sort: String
     var start: Int
-
-    typealias Query = (String, String, Int)
-//    var inputQuery: Observable<Query> = Observable(("", "sim", 1))
-//    let inputRequest: Observable<Void> = Observable(())
-//    let inputPrefetch: Observable<[IndexPath]> = Observable([])
-//    
-//    let outputRequest: Observable<[ShoppingDetail?]> = Observable([])
-//    let outputReloadAction: Observable<Void> = Observable(())
-//    var outputStart: Observable<Int> = Observable(1)
-//    let outputTotal: Observable<Int> = Observable(0)
-//    var outputIsEnd: Observable<Bool> = Observable(false)
     
     init(keyword: String) {
         
@@ -49,6 +40,7 @@ final class SearchResultViewModel: BaseViewModel {
         
         let totalCount = BehaviorRelay(value: 0)
         let shoppingDetail = BehaviorRelay(value: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
+        let startPage = BehaviorRelay(value: 1)
         
         // MARK: 화면 진입 시 첫 통신
         AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: keyword, sortName: sort, start: start))
@@ -74,6 +66,7 @@ final class SearchResultViewModel: BaseViewModel {
                     let sortList = Sort.allCases.map { $0.query }
                     this.sort = sortList[tag]
                     this.start = 1
+                    startPage.accept(this.start)
                     
                     AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: this.keyword, sortName: this.sort, start: this.start))
                         .catch { error in
@@ -93,29 +86,12 @@ final class SearchResultViewModel: BaseViewModel {
                 }
                 .disposed(by: disposeBag)
         }
-            
-            
-//            .disposed(by: disposeBag)
+ 
         
         return Output(
             totalCount: totalCount.asDriver(),
-            shoppingDetail: shoppingDetail.asDriver()
+            shoppingDetail: shoppingDetail.asDriver(),
+            startPage: startPage.asDriver()
         )
     }
-    
-//    private func checkPagenation(_ itemCount: Int) {
-//        
-//        let list = outputRequest.value
-//        var start = self.outputStart.value
-//        var end = self.outputIsEnd.value
-//        let total = self.outputTotal.value
-//        
-//        print("list: ", list.count)
-//        if list.count - 5 == itemCount && list.count < total {
-//            start += list.count
-//            print("start: ", start)
-//        } else if list.count >= total {
-//            end = true
-//        }
-//    }
 }

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -36,34 +36,49 @@ final class SearchResultViewModel: BaseViewModel {
     let outputTotal: Observable<Int> = Observable(0)
     var outputIsEnd: Observable<Bool> = Observable(false)
     
-    init() {
+    init(keyword: String) {
         
-        inputQuery.lazyBind { data in
-            
-            let keyword = data.0
-            let sort = data.1
-            let start = data.2
-            
-            print("inputkeyword.bind====", data)
-            self.getSearchResult(keyword, sort, start)
-        }
-        
-        inputRequest.lazyBind { _ in
-            let keyword = self.inputQuery.value.0
-            let sort = self.inputQuery.value.1
-            let start = self.inputQuery.value.2
-            
-            print("inputRequest.bind====", keyword, sort, start)
-            self.getSearchResult(keyword, sort, start)
-        }
-        
-        inputPrefetch.lazyBind { indexPaths in
-            
-            for item in indexPaths {
+        AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: keyword, sortName: "sim", start: 1))
+            .catch { error in
                 
-                self.checkPagenation(item.row)
+                print("shopping error", error)
+                
+                let data = Shopping(total: 0, items: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
+                return Single.just(data)
             }
-        }
+            .debug("shopping")
+            .asObservable()
+            .bind(with: self) { this, value in
+                dump(value)
+            }
+            .disposed(by: disposeBag)
+        
+//        inputQuery.lazyBind { data in
+//            
+//            let keyword = data.0
+//            let sort = data.1
+//            let start = data.2
+//            
+//            print("inputkeyword.bind====", data)
+//            self.getSearchResult(keyword, sort, start)
+//        }
+//        
+//        inputRequest.lazyBind { _ in
+//            let keyword = self.inputQuery.value.0
+//            let sort = self.inputQuery.value.1
+//            let start = self.inputQuery.value.2
+//            
+//            print("inputRequest.bind====", keyword, sort, start)
+//            self.getSearchResult(keyword, sort, start)
+//        }
+//        
+//        inputPrefetch.lazyBind { indexPaths in
+//            
+//            for item in indexPaths {
+//                
+//                self.checkPagenation(item.row)
+//            }
+//        }
     }
     
     private func getSearchResult(_ keyword: String, _ sort: String, _ start: Int) {

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -6,9 +6,24 @@
 //
 
 import Foundation
+import RxCocoa
+import RxSwift
 
-
-final class SearchResultViewModel {
+final class SearchResultViewModel: BaseViewModel {
+    
+    struct Input {
+        
+    }
+    
+    struct Output {
+        
+    }
+    
+    var disposeBag: DisposeBag = DisposeBag()
+    
+    func transform(input: Input) -> Output {
+        return Output()
+    }
 
     typealias Query = (String, String, Int)
     var inputQuery: Observable<Query> = Observable(("", "sim", 1))

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -29,9 +29,9 @@ final class SearchResultViewModel: BaseViewModel {
     let buttonTitle = Sort.allCases
     
     let keyword: String
-    var sort: String
-    var start: Int
-    var isEnd: Bool
+    private var sort: String
+    private var start: Int
+    private var isEnd: Bool
     
     init(keyword: String) {
         
@@ -114,10 +114,10 @@ final class SearchResultViewModel: BaseViewModel {
  
         input.prefetchIndexPath
             .bind(with: self) { this, indexPaths in
-                print("result.count===", results.count)
+                
                 for item in indexPaths {
                     if (results.count - 6 == item.item) && results.count < totalCount.value && !this.isEnd {
-                        this.start += results.count
+                        this.start += 30
                         
                         print("totalCount===", totalCount)
                         print("start===", this.start)

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -21,7 +21,7 @@ final class SearchResultViewModel: BaseViewModel {
         let totalCount: Driver<Int>
         let shoppingDetail: Driver<[ShoppingDetail]>
         let startPage: Driver<Int>
-        let errorMessage: Driver<String>
+        let errorMessage: PublishRelay<String>
     }
     
     var disposeBag: DisposeBag = DisposeBag()
@@ -48,7 +48,7 @@ final class SearchResultViewModel: BaseViewModel {
         let totalCount = BehaviorRelay(value: 0)
         let shoppingDetail = BehaviorRelay(value: results)
         let startPage = BehaviorRelay(value: 1)
-        let errorMessage = BehaviorRelay(value: "")
+        let errorMessage = PublishRelay<String>()
         
         // MARK: 화면 진입 시 첫 통신
         AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: keyword, sortName: sort, start: start))
@@ -160,7 +160,7 @@ final class SearchResultViewModel: BaseViewModel {
             totalCount: totalCount.asDriver(),
             shoppingDetail: shoppingDetail.asDriver(),
             startPage: startPage.asDriver(),
-            errorMessage: errorMessage.asDriver()
+            errorMessage: errorMessage
         )
     }
 }

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -14,39 +14,54 @@ final class SearchResultViewModel: BaseViewModel {
     struct Input {
         // 필터링 버튼의 태그를 전달받기 (버튼탭을 통해서)
         let buttonTag: [Observable<Int>]
+        let prefetchIndexPath: ControlEvent<[IndexPath]>
     }
     
     struct Output {
         let totalCount: Driver<Int>
         let shoppingDetail: Driver<[ShoppingDetail]>
         let startPage: Driver<Int>
+        let errorMessage: Driver<String>
     }
     
     var disposeBag: DisposeBag = DisposeBag()
+    private let group = DispatchGroup()
     let buttonTitle = Sort.allCases
     
     let keyword: String
     var sort: String
     var start: Int
+    var isEnd: Bool
     
     init(keyword: String) {
         
         self.keyword = keyword
         self.sort = Sort.정확도.query
         self.start = 1
+        self.isEnd = false
     }
     
     func transform(input: Input) -> Output {
         
+        var results: [ShoppingDetail] = []
+        
         let totalCount = BehaviorRelay(value: 0)
-        let shoppingDetail = BehaviorRelay(value: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
+        let shoppingDetail = BehaviorRelay(value: results)
         let startPage = BehaviorRelay(value: 1)
+        let errorMessage = BehaviorRelay(value: "")
         
         // MARK: 화면 진입 시 첫 통신
         AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: keyword, sortName: sort, start: start))
             .catch { error in
                 
-                print("shopping error", error)
+                switch error as? ShoppingError {
+                case .invalidURL: errorMessage.accept(ShoppingError.invalidURL.message)
+                case let .statudError(code): errorMessage.accept(ShoppingError.statudError(code: code).message)
+                case .unknownResponse: errorMessage.accept(ShoppingError.unknownResponse.message)
+                default:
+                    print("잘못된 에러")
+                    break
+                }
                 
                 let data = Shopping(total: 0, items: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
                 return Single.just(data)
@@ -54,21 +69,26 @@ final class SearchResultViewModel: BaseViewModel {
             .debug("shopping")
             .asObservable()
             .bind(with: self) { this, value in
-                shoppingDetail.accept(value.items)
+                results.append(contentsOf: value.items)
+                
+                shoppingDetail.accept(results)
                 totalCount.accept(value.total)
             }
             .disposed(by: disposeBag)
         
-        // MARK: 전달 받은 버튼의 태그값 활용
+        // MARK: 필터링 - 전달 받은 버튼의 태그값 활용
         input.buttonTag.forEach { value in
             value
                 .distinctUntilChanged()
                 .bind(with: self) { this, tag in
+                    
+                    results = []
+                    
                     let sortList = Sort.allCases.map { $0.query }
                     this.sort = sortList[tag]
                     this.start = 1
-                    startPage.accept(this.start)
                     
+                    this.group.enter()
                     AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: this.keyword, sortName: this.sort, start: this.start))
                         .catch { error in
                             
@@ -80,19 +100,67 @@ final class SearchResultViewModel: BaseViewModel {
                         .debug("shopping")
                         .asObservable()
                         .bind(with: self) { this, value in
-                            shoppingDetail.accept(value.items)
+                            
+                            results.append(contentsOf: value.items)
+                            
+                            shoppingDetail.accept(results)
                             totalCount.accept(value.total)
+                            
+                            this.group.leave()
                         }
                         .disposed(by: this.disposeBag)
                 }
                 .disposed(by: disposeBag)
         }
+        
+        group.notify(queue: .main) {
+            startPage.accept(self.start)
+        }
  
+        // MARK: Pagenation (왜 작동을 안할까?)
+        input.prefetchIndexPath
+            .bind(with: self) { this, indexPaths in
+                print("result.count===", results.count)
+                for item in indexPaths {
+                    if (results.count - 6 == item.item) && results.count < totalCount.value && !this.isEnd {
+                        this.start += results.count
+                        
+                        print("totalCount===", totalCount)
+                        print("start===", this.start)
+                        print("isEnd===", this.isEnd)
+                        
+                        AlamofireManager.shared.callRequestByObservable(type: Shopping.self, api: .shopping(keyword: this.keyword, sortName: this.sort, start: this.start))
+                            .catch { error in
+                                
+                                print("shopping error", error)
+                                
+                                let data = Shopping(total: 0, items: [ShoppingDetail(title: "", image: "", price: "", mallName: "")])
+                                return Single.just(data)
+                            }
+                            .debug("shopping")
+                            .asObservable()
+                            .bind(with: self) { this, value in
+                                
+                                results.append(contentsOf: value.items)
+                                
+                                shoppingDetail.accept(results)
+                                totalCount.accept(value.total)
+                                
+                                if results.count >= value.total {
+                                    this.isEnd = true
+                                }
+                            }
+                            .disposed(by: this.disposeBag)
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
         
         return Output(
             totalCount: totalCount.asDriver(),
             shoppingDetail: shoppingDetail.asDriver(),
-            startPage: startPage.asDriver()
+            startPage: startPage.asDriver(),
+            errorMessage: errorMessage.asDriver()
         )
     }
 }

--- a/WSShopping/ViewModel/SearchResultViewModel.swift
+++ b/WSShopping/ViewModel/SearchResultViewModel.swift
@@ -62,6 +62,7 @@ final class SearchResultViewModel: BaseViewModel {
         // MARK: 전달 받은 버튼의 태그값 활용
         input.buttonTag.forEach { value in
             value
+                .distinctUntilChanged()
                 .bind(with: self) { this, tag in
                     let sortList = Sort.allCases.map { $0.query }
                     this.sort = sortList[tag]


### PR DESCRIPTION
## 한 일

1. 필터링 버튼 수정
- 기존에 index로 버튼 클릭 시 on/off를 관리하고 색상을 변경하던 로직을 UIButton의 isSelected를 활용해 조금 더 간편하게 사용할 수 있도록 수정

2. 네트워크 통신 callRequest 메서드 RxSwift 반영
- 커스텀 Single<T> 타입 반환하도록 구성
- 네트워크 오류 처리가 미흡한 것 같아 수정 예정

3. MainViewController 전체 RxSwift 적용
- 해당 화면에서 검색한 단어를 검색결과 ViewController의 생성자로 keyword를 전달해 화면 진입 시 바로 첫 통신 진행하도록 구현

4. 검색결과 화면의 CollectionView RxSwift로 dataSource 전달하기

5. 현재와 다른 필터링 버튼 클릭 시 스크롤 최상단으로 이동하도록 구현
- 똑같은 정렬 버튼 클릭 시 네트워크 통신 재진행되지 않도록 막기

6. 페이지네이션 구현
- 현재 prefetch로 되어있는데 다른 방법으로 구현하는 방향으로 시도 필요