### PR TITLE
[Chore] #27 네트워크 오류 처리 세분화

### DIFF
--- a/WSShopping/Extension/UIViewController+Extension.swift
+++ b/WSShopping/Extension/UIViewController+Extension.swift
@@ -21,10 +21,13 @@ extension UIViewController {
         
     }
     
-    func alertError(message: String) {
-        let message = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+    func alertError(title: String, message: String) {
+        let message = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
-        let okay = UIAlertAction(title: "확인", style: .cancel)
+        let okay = UIAlertAction(title: "확인", style: .cancel) { [weak self] _ in
+            guard let self else { return }
+            self.navigationController?.popViewController(animated: true)
+        }
         message.addAction(okay)
         
         present(message, animated: true)

--- a/WSShopping/Model/AlamofireManager.swift
+++ b/WSShopping/Model/AlamofireManager.swift
@@ -32,7 +32,14 @@ final class AlamofireManager {
                 case .success(let result):
                     value(.success(result))
                 case .failure(let error):
-                    value(.failure(error))
+
+                    guard let statusCode = response.response?.statusCode else {
+                        value(.failure(ShoppingError.unknownResponse))
+                        return
+                    }
+                    switch statusCode {
+                    default: value(.failure(ShoppingError.statudError(code: statusCode, message: error.localizedDescription)))
+                    }
                 }
             }
             

--- a/WSShopping/Model/ShoppingError.swift
+++ b/WSShopping/Model/ShoppingError.swift
@@ -10,7 +10,18 @@ import Foundation
 enum ShoppingError: Error {
     case invalidURL
     case unknownResponse
-    case statudError(code: Int)
+    case statudError(code: Int, message: String)
+    
+    var title: String {
+        switch self {
+        case .invalidURL:
+            return "URL Error"
+        case .unknownResponse:
+            return "unknownedResponse Error"
+        case let .statudError(code, _):
+            return "에러코드: \(code)"
+        }
+    }
     
     var message: String {
         switch self {
@@ -18,8 +29,8 @@ enum ShoppingError: Error {
             return "잘못된 URL 접근입니다."
         case .unknownResponse:
             return "unknownedResponse Error"
-        case .statudError(let code):
-            return "error \(code): status Error"
+        case let .statudError(_, message):
+            return "\(message)"
         }
     }
 }

--- a/WSShopping/View/ViewController/DetailWebViewViewController.swift
+++ b/WSShopping/View/ViewController/DetailWebViewViewController.swift
@@ -43,7 +43,7 @@ final class DetailWebViewViewController: UIViewController, WKNavigationDelegate 
     private func configure() {
         view.addSubview(webView)
         webView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.edges.equalTo(view.safeAreaLayoutGuide)
         }
     }
     

--- a/WSShopping/View/ViewController/SearchResultViewController.swift
+++ b/WSShopping/View/ViewController/SearchResultViewController.swift
@@ -98,8 +98,8 @@ final class SearchResultViewController: UIViewController {
             .disposed(by: disposeBag)
         
         output.errorMessage
-            .bind(with: self) { this, message in
-                this.alertError(message: message)
+            .bind(with: self) { this, errorCode in
+                this.alertError(title: errorCode.title, message: errorCode.message)
             }
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## 한 일

> 기존에 statusCode를 분리한 채로 오류를 처리하지 못한 부분에 대해 처리하는 과정

1. StatusCode를 알럿 메시지의 타이틀로 설정
2. 오류 body 부분을 메시지로 들어가도록 설정 >> error의 localizedDescription 활용
>> 1,2번 둘 다 ShoppinError 열거형 내 계산속성으로 설정


![Simulator Screen Recording - iPhone 16 Pro - 2025-02-27 at 15 34 01](https://github.com/user-attachments/assets/3856108b-62b6-48ec-ab3c-033a7189b258)
