### PR TITLE
[Design] #36 WishFolder 뷰 컨트롤러와 WishList 뷰 레이아웃 구성 및 컨트롤러 간 연결 

### DIFF
--- a/WSShopping/BaseView/BaseUITextField.swift
+++ b/WSShopping/BaseView/BaseUITextField.swift
@@ -12,7 +12,7 @@ final class BaseUITextField: UITextField {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        let placeHolder = "사고싶은 물건을 입력해보세요!"
+        let placeHolder = "항목을 입력해보세요!"
         
         self.attributedPlaceholder = NSAttributedString(string: placeHolder, attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 14, weight: .medium), NSAttributedString.Key.foregroundColor: UIColor.lightGray])
         self.keyboardType = .default

--- a/WSShopping/Model/WishFolderTable.swift
+++ b/WSShopping/Model/WishFolderTable.swift
@@ -15,7 +15,7 @@ final class WishFolderTable: Object {
     
     @Persisted var content: List<WishListTable>
     
-    convenience init(id: ObjectId, name: String) {
+    convenience init(name: String) {
         self.init()
         
         self.id = id
@@ -23,7 +23,7 @@ final class WishFolderTable: Object {
     }
 }
 
-enum FolderName: String {
+enum FolderName: String, CaseIterable {
     case 화장품
     case 맛집
     case 버킷리스트

--- a/WSShopping/Model/WishFolderTable.swift
+++ b/WSShopping/Model/WishFolderTable.swift
@@ -1,0 +1,31 @@
+//
+//  WishFolderTable.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 3/5/25.
+//
+
+import Foundation
+import RealmSwift
+
+final class WishFolderTable: Object {
+    
+    @Persisted var id: ObjectId
+    @Persisted var name: String
+    
+    @Persisted var content: List<WishListTable>
+    
+    convenience init(id: ObjectId, name: String) {
+        self.init()
+        
+        self.id = id
+        self.name = name
+    }
+}
+
+enum FolderName: String {
+    case 화장품
+    case 맛집
+    case 버킷리스트
+    case 블로그작성
+}

--- a/WSShopping/Model/WishListTable.swift
+++ b/WSShopping/Model/WishListTable.swift
@@ -1,0 +1,26 @@
+//
+//  WishListTable.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 3/5/25.
+//
+
+import Foundation
+import RealmSwift
+
+final class WishListTable: Object {
+    
+    @Persisted var id: ObjectId
+    @Persisted var wishName: String
+    @Persisted var regDate: Date
+    
+    @Persisted(originProperty: "content") var folder: LinkingObjects<WishFolderTable>
+    
+    convenience init(id: ObjectId, wishName: String, regDate: Date) {
+        self.init()
+        
+        self.id = id
+        self.wishName = wishName
+        self.regDate = regDate
+    }
+}

--- a/WSShopping/Model/WishListTable.swift
+++ b/WSShopping/Model/WishListTable.swift
@@ -16,7 +16,7 @@ final class WishListTable: Object {
     
     @Persisted(originProperty: "content") var folder: LinkingObjects<WishFolderTable>
     
-    convenience init(id: ObjectId, wishName: String, regDate: Date) {
+    convenience init(wishName: String, regDate: Date) {
         self.init()
         
         self.id = id

--- a/WSShopping/Protocol/BaseRepository.swift
+++ b/WSShopping/Protocol/BaseRepository.swift
@@ -8,10 +8,10 @@
 import Foundation
 import RealmSwift
 
-protocol BaseRepository: AnyObject {
+protocol BaseRepository: AnyObject, FolderRepository {
     func getFileURL()
-    func fetchAll<T: Object>() -> Results<T>
-    func createItem()
+    func fetchAll<T: Object>(_ object: T.Type) -> Results<T>
+    func createItem<T: Object>(_ object: T)
     func deleteItem<T: Object>(_ object: T)
     func updateItem<T: Object>(_ object: T.Type, value: [String: Any])
 }

--- a/WSShopping/Protocol/BaseRepository.swift
+++ b/WSShopping/Protocol/BaseRepository.swift
@@ -1,0 +1,17 @@
+//
+//  BaseRepository.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 3/5/25.
+//
+
+import Foundation
+import RealmSwift
+
+protocol BaseRepository: AnyObject {
+    func getFileURL()
+    func fetchAll<T: Object>() -> Results<T>
+    func createItem()
+    func deleteItem<T: Object>(_ object: T)
+    func updateItem<T: Object>(_ object: T.Type, value: [String: Any])
+}

--- a/WSShopping/Protocol/FolderRepository.swift
+++ b/WSShopping/Protocol/FolderRepository.swift
@@ -1,0 +1,13 @@
+//
+//  FolderRepository.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 3/5/25.
+//
+
+import Foundation
+import RealmSwift
+
+protocol FolderRepository: AnyObject {
+    func createItemInFolder(foler: WishFolderTable)
+}

--- a/WSShopping/Protocol/FolderRepository.swift
+++ b/WSShopping/Protocol/FolderRepository.swift
@@ -9,5 +9,5 @@ import Foundation
 import RealmSwift
 
 protocol FolderRepository: AnyObject {
-    func createItemInFolder(foler: WishFolderTable)
+    func createItemInFolder(_ object: WishListTable, folder: WishFolderTable)
 }

--- a/WSShopping/Repository/RealmRepository.swift
+++ b/WSShopping/Repository/RealmRepository.swift
@@ -1,0 +1,63 @@
+//
+//  RealmRepository.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 3/5/25.
+//
+
+import Foundation
+import RealmSwift
+
+final class RealmRepository: BaseRepository {
+    
+    private let realm = try! Realm()
+    
+    func getFileURL() {
+        print(realm.configuration.fileURL ?? "")
+    }
+    
+    func fetchAll<T: Object>(_ object: T.Type) -> Results<T> {
+        return realm.objects(object.self)
+    }
+    
+    func createItem<T: Object>(_ object: T) {  // folder 테이블 상관없이 레코드 추가
+        do {
+            try realm.write {
+                realm.add(object)
+            }
+        } catch {
+            print("==realm create 실패==")
+        }
+    }
+    
+    func deleteItem<T: Object>(_ object: T) {
+        do {
+            try realm.write {
+                realm.delete(object)
+            }
+        } catch {
+            print("==realm delete 실패==")
+        }
+    }
+    
+    func updateItem<T: Object>(_ object: T.Type, value: [String : Any]) {
+        do {
+            try realm.write {
+                realm.create(object.self, value: value, update: .modified)
+            }
+        } catch {
+            print("==realm update 실패==")
+        }
+    }
+    
+    // TODO: 질문 - Generic 내에 특정 타입에 대한 메서드...
+    func createItemInFolder(_ object: WishListTable, folder: WishFolderTable) {  // folder의 content에 담기위한 메서드
+        do {
+            try realm.write {
+                folder.content.append(object)
+            }
+        } catch {
+            print("==realm createFolder 실패==")
+        }
+    }
+}

--- a/WSShopping/View/ViewController/MainViewController.swift
+++ b/WSShopping/View/ViewController/MainViewController.swift
@@ -15,6 +15,8 @@ final class MainViewController: UIViewController {
     private let viewModel = MainViewModel()
     private let disposeBag = DisposeBag()
     
+    private let repository: BaseRepository = RealmRepository()
+    
     private let searchbar = UISearchBar()
     private let defaultImage = UIImageView()
     private let defaultLabel = UILabel()
@@ -24,7 +26,17 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        print(RealmManager.shared.checkDefaultRealmLocation())
+        print(repository.getFileURL())
+      
+        let data = repository.fetchAll(WishFolderTable.self)
+        // MARK: 앱 빌드 시 Folder data 없을 시 create 하도록 설정
+        if data.isEmpty {
+            FolderName.allCases.forEach {
+                repository.createItem(WishFolderTable(name: $0.rawValue))
+            }
+        } else {
+            print("저장된 folderName 있음")
+        }
         
         configHierarchy()
         configLayout()
@@ -78,7 +90,7 @@ final class MainViewController: UIViewController {
         
         rightBarItem.rx.tap
             .bind(with: self) { this, _ in
-                let vc = WishListViewController()
+                let vc = WishFolderViewController()
                 this.navigationController?.pushViewController(vc, animated: true)
             }
             .disposed(by: disposeBag)

--- a/WSShopping/View/ViewController/WishFolderViewController.swift
+++ b/WSShopping/View/ViewController/WishFolderViewController.swift
@@ -90,9 +90,12 @@ extension WishFolderViewController: UICollectionViewDelegate {
         let data = folderList[indexPath.item]
         
         // TODO: 위시리스트로 push
-        let vc = WishListViewController(title: data.name)
+        let vc = WishListViewController(folderData: data)
         
         vc.wishList = Array(data.content)
+        vc.popVC = { [weak self] in
+            self?.collectionView.reloadData()
+        }
         
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/WSShopping/View/ViewController/WishFolderViewController.swift
+++ b/WSShopping/View/ViewController/WishFolderViewController.swift
@@ -15,6 +15,7 @@ fileprivate enum FolderSection: CaseIterable {
 final class WishFolderViewController: UIViewController {
     
     private let repository: BaseRepository = RealmRepository()
+    private lazy var folderList = Array(repository.fetchAll(WishFolderTable.self))
     
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionviewLayout())
     private var dataSource: UICollectionViewDiffableDataSource<FolderSection, WishFolderTable>?
@@ -74,8 +75,6 @@ final class WishFolderViewController: UIViewController {
  
     private func updateSnapshot() {
         
-        let folderList = Array(repository.fetchAll(WishFolderTable.self))
-        
         var snapshot = NSDiffableDataSourceSnapshot<FolderSection, WishFolderTable>()
         snapshot.appendSections(FolderSection.allCases)
         snapshot.appendItems(folderList, toSection: FolderSection.first)
@@ -88,7 +87,14 @@ extension WishFolderViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
+        let data = folderList[indexPath.item]
+        
         // TODO: 위시리스트로 push
+        let vc = WishListViewController(title: data.name)
+        
+        vc.wishList = Array(data.content)
+        
+        navigationController?.pushViewController(vc, animated: true)
     }
 }
 
@@ -106,6 +112,7 @@ extension WishFolderViewController {
     private func configureView() {
         view.backgroundColor = .white
         navigationItem.title = "Wish Folder"
+        navigationItem.backButtonTitle = ""
         collectionView.keyboardDismissMode = .onDrag
         collectionView.delegate = self
 

--- a/WSShopping/View/ViewController/WishFolderViewController.swift
+++ b/WSShopping/View/ViewController/WishFolderViewController.swift
@@ -1,0 +1,29 @@
+//
+//  WishFolderViewController.swift
+//  WSShopping
+//
+//  Created by Lee Wonsun on 3/5/25.
+//
+
+import UIKit
+
+class WishFolderViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WSShopping/View/ViewController/WishListViewController.swift
+++ b/WSShopping/View/ViewController/WishListViewController.swift
@@ -119,7 +119,11 @@ extension WishListViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
+        let deletedItem = wishList[indexPath.item]
         wishList.remove(at: indexPath.item)
+        
+        repository.deleteItem(deletedItem)
+        
         updateSnapshot()
     }
 }

--- a/WSShopping/View/ViewController/WishListViewController.swift
+++ b/WSShopping/View/ViewController/WishListViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-fileprivate enum Section: CaseIterable {
+fileprivate enum WishSection: CaseIterable {
     case first
 }
 
@@ -17,7 +17,7 @@ final class WishListViewController: UIViewController, UITextFieldDelegate {
     private let textfield = BaseUITextField()
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionviewLayout())
     
-    private var dataSource: UICollectionViewDiffableDataSource<Section, WishProduct>?
+    private var dataSource: UICollectionViewDiffableDataSource<WishSection, WishProduct>?
     
     private var wishList: [WishProduct] = []
 
@@ -80,9 +80,9 @@ final class WishListViewController: UIViewController, UITextFieldDelegate {
     
     private func updateSnapshot() {
         
-        var snapshot = NSDiffableDataSourceSnapshot<Section, WishProduct>()
-        snapshot.appendSections(Section.allCases)
-        snapshot.appendItems(wishList, toSection: Section.first)
+        var snapshot = NSDiffableDataSourceSnapshot<WishSection, WishProduct>()
+        snapshot.appendSections(WishSection.allCases)
+        snapshot.appendItems(wishList, toSection: WishSection.first)
         
         dataSource?.apply(snapshot)
     }

--- a/WSShopping/View/ViewController/WishListViewController.swift
+++ b/WSShopping/View/ViewController/WishListViewController.swift
@@ -17,10 +17,22 @@ final class WishListViewController: UIViewController, UITextFieldDelegate {
     private let textfield = BaseUITextField()
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionviewLayout())
     
-    private var dataSource: UICollectionViewDiffableDataSource<WishSection, WishProduct>?
+    private var dataSource: UICollectionViewDiffableDataSource<WishSection, WishListTable>?
     
-    private var wishList: [WishProduct] = []
-
+    var wishList: [WishListTable] = []
+    var navigationTitle: String
+    
+    init(title: String) {
+        self.navigationTitle = title
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -38,7 +50,7 @@ final class WishListViewController: UIViewController, UITextFieldDelegate {
         
         guard let keyword = textfield.text else { return }
         
-        let product = WishProduct(name: keyword)
+        let product = WishListTable(wishName: keyword, regDate: Date())
         wishList.append(product)
         updateSnapshot()
         
@@ -47,13 +59,13 @@ final class WishListViewController: UIViewController, UITextFieldDelegate {
  
     private func configureDataSource() {
         
-        let registration = UICollectionView.CellRegistration<UICollectionViewListCell, WishProduct> { cell, indexPath, item in
+        let registration = UICollectionView.CellRegistration<UICollectionViewListCell, WishListTable> { cell, indexPath, item in
             
             var content = UIListContentConfiguration.accompaniedSidebarSubtitleCell()
-            content.text = item.name
+            content.text = item.wishName
             content.textProperties.color = .label
             content.textProperties.font = .systemFont(ofSize: 16, weight: .semibold)
-            content.secondaryText = item.date.dateToString()
+            content.secondaryText = item.regDate.dateToString()
             content.secondaryTextProperties.color = .darkGray
             content.secondaryTextProperties.font = .systemFont(ofSize: 13, weight: .medium)
             content.image = UIImage(systemName: "checkmark.square")
@@ -80,7 +92,7 @@ final class WishListViewController: UIViewController, UITextFieldDelegate {
     
     private func updateSnapshot() {
         
-        var snapshot = NSDiffableDataSourceSnapshot<WishSection, WishProduct>()
+        var snapshot = NSDiffableDataSourceSnapshot<WishSection, WishListTable>()
         snapshot.appendSections(WishSection.allCases)
         snapshot.appendItems(wishList, toSection: WishSection.first)
         
@@ -112,7 +124,7 @@ extension WishListViewController {
     
     private func configureView() {
         view.backgroundColor = .white
-        navigationItem.title = "위시리스트"
+        navigationItem.title = navigationTitle
         collectionView.keyboardDismissMode = .onDrag
         textfield.delegate = self
         collectionView.delegate = self


### PR DESCRIPTION
## 한 일

1. Realm 모델 데이터 생성
2. RealmRepository에 사용할 Realm protocol 생성
3. 전역적으로 사용 할 RealmRepository 생성
4. 정해진 folder name으로 WishFolderTable 생성되도록 구현
- 이미 저장된 데이터 있을 시 create 하지 않고 없을 때만 진행하도록 조건 수정
5. WishFolderVC -> WishListVC 이동할 때 Folder의 정보와 그 안에 속해있는 WishList 정보 전달
6. 위시리스트 화면에서 서치바로 항목 추가할 시 Realm에 저장되도록 구현
7. 위시리스트 항목 중 희망하는 부분 선택하면 리스트에서 삭제되고 Realm에서도 반영되도록 수정

![Simulator Screen Recording - iPhone 16 Pro - 2025-03-06 at 09 17 54](https://github.com/user-attachments/assets/cac58073-c2d1-4ab4-bfa9-d2b0b60d8ec1)